### PR TITLE
Fix checkstyle tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,3 +37,15 @@ dependencies {
     testCompile project('triglav-client-java')
 }
 
+checkstyle {
+    configFile = file("${project.rootDir}/config/checkstyle/checkstyle.xml")
+    toolVersion = '6.14.1'
+}
+checkstyleMain {
+    configFile = file("${project.rootDir}/config/checkstyle/default.xml")
+    ignoreFailures = true
+}
+checkstyleTest {
+    configFile = file("${project.rootDir}/config/checkstyle/default.xml")
+    ignoreFailures = true
+}


### PR DESCRIPTION
checkstyle tasks were broken, so I fixed.

#### failed logs

```
$ ./gradlew check
...<snip>...
:checkstyleMain FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':checkstyleMain'.
> Unable to create a Checker: cannot initialize module TreeWalker - Property 'sortStaticImportsAlphabetically' in module ImportOrder does not exist, please check the documentation

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

```